### PR TITLE
Trigger rebuild removing all `>=` pinnings

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
-- '12.0'
+- '12.1'
 python_min:
 - '3.10'
 target_platform:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -18,12 +18,16 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
 - '12.1'
+libboost_python_devel:
+- '1.86'
 python_min:
 - '3.10'
 spdlog:
 - '1.17'
 target_platform:
 - linux-64
+tbb_devel:
+- '2022'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,8 +20,12 @@ fmt:
 - '12.1'
 python_min:
 - '3.10'
+spdlog:
+- '1.17'
 target_platform:
 - linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+zlib:
+- '1'

--- a/.ci_support/migrations/fmt121_spdlog117.yaml
+++ b/.ci_support/migrations/fmt121_spdlog117.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for fmt 12.1 and spdlog 1.17
+  kind: version
+  migration_number: 1
+migrator_ts: 1767674179.1402016
+fmt:
+- '12.1'
+spdlog:
+- '1.17'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -20,6 +20,8 @@ cxx_compiler_version:
 - '19'
 fmt:
 - '12.1'
+libboost_python_devel:
+- '1.86'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 python_min:
@@ -28,6 +30,8 @@ spdlog:
 - '1.17'
 target_platform:
 - osx-64
+tbb_devel:
+- '2022'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -24,8 +24,12 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 python_min:
 - '3.10'
+spdlog:
+- '1.17'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+zlib:
+- '1'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -19,7 +19,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 fmt:
-- '12.0'
+- '12.1'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 python_min:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2022
 fmt:
-- '12.0'
+- '12.1'
 python_min:
 - '3.10'
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -12,5 +12,9 @@ fmt:
 - '12.1'
 python_min:
 - '3.10'
+spdlog:
+- '1.17'
 target_platform:
 - win-64
+zlib:
+- '1'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -10,11 +10,15 @@ cxx_compiler:
 - vs2022
 fmt:
 - '12.1'
+libboost_python_devel:
+- '1.86'
 python_min:
 - '3.10'
 spdlog:
 - '1.17'
 target_platform:
 - win-64
+tbb_devel:
+- '2022'
 zlib:
 - '1'

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -72,7 +72,7 @@ outputs:
         - fmt
       run_exports:
         - ${{ pin_subpackage('libcoacd', upper_bound='x.x.x') }}
-        - ${{ pin_compatible('openvdb', max_pin='x.x') }}
+        - ${{ pin_compatible('openvdb', upper_bound='x.x') }}
       ignore_run_exports:
         from_package:
           - libboost-python-devel

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -70,9 +70,10 @@ outputs:
         - spdlog
         - eigen
         - fmt
+      run:
+        - ${{ pin_compatible('openvdb', upper_bound='x.x') }}
       run_exports:
         - ${{ pin_subpackage('libcoacd', upper_bound='x.x.x') }}
-        - ${{ pin_compatible('openvdb', upper_bound='x.x') }}
       ignore_run_exports:
         from_package:
           - libboost-python-devel

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -72,6 +72,7 @@ outputs:
         - fmt
       run_exports:
         - ${{ pin_subpackage('libcoacd', upper_bound='x.x.x') }}
+        - ${{ pin_compatible('openvdb', max_pin='x.x') }}
       ignore_run_exports:
         from_package:
           - libboost-python-devel

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -64,9 +64,9 @@ outputs:
         - pkg-config
       host:
         - zlib
-        - libboost-python-devel >=1.81.0
-        - openvdb >=8.2.0
-        - tbb-devel >=2022.0.0
+        - libboost-python-devel
+        - openvdb
+        - tbb-devel
         - spdlog
         - eigen
         - fmt

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -63,12 +63,12 @@ outputs:
         - ninja
         - pkg-config
       host:
-        - zlib >=1.2.11
+        - zlib
         - libboost-python-devel >=1.81.0
         - openvdb >=8.2.0
         - tbb-devel >=2022.0.0
-        - spdlog >=1.8.2
-        - eigen >=3.4.0
+        - spdlog
+        - eigen
         - fmt
       run_exports:
         - ${{ pin_subpackage('libcoacd', upper_bound='x.x.x') }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR started as a rebuild for `fmt`, but it then evolved to be a PR that beyond that also removes all other `>=` pinnings that were constraining older major versions to `run_exports`.